### PR TITLE
Update vagrant_provision.sh

### DIFF
--- a/scripts/vagrant_provision.sh
+++ b/scripts/vagrant_provision.sh
@@ -3,7 +3,7 @@ source /etc/lsb-release
 wget https://apt.puppetlabs.com/puppet-release-${DISTRIB_CODENAME}.deb
 dpkg -i puppet-release-${DISTRIB_CODENAME}.deb
 apt-get update
-apt-get -y install git puppet-agent
+apt-get -y install git puppet-agent r10k
 echo 'Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin"' >/etc/sudoers.d/puppet
 /opt/puppetlabs/puppet/bin/gem install gpgme --no-rdoc --no-ri
 /opt/puppetlabs/puppet/bin/gem install hiera-eyaml-gpg --no-rdoc --no-ri


### PR DESCRIPTION
The vagrant VM does not have r10k installed so I have added it to the provision script. The issue was opened for this in July:

https://github.com/bitfield/puppet-beginners-guide-3/issues/2